### PR TITLE
Changes transaction type logic

### DIFF
--- a/src/data/transaction.json
+++ b/src/data/transaction.json
@@ -5,7 +5,7 @@
     "senderId": 1,
     "receiverId": 3,
     "reference": "Bonus",
-    "amount": -2125,
+    "amount": 2125,
     "transactionDate": 1670584800000
   },
   {
@@ -23,7 +23,7 @@
     "senderId": 1,
     "receiverId": 4,
     "reference": "Expense",
-    "amount": -1503,
+    "amount": 1503,
     "transactionDate": 1670234400000
   },
   {
@@ -41,7 +41,7 @@
     "senderId": 1,
     "receiverId": 4,
     "reference": "Salary",
-    "amount": -3109,
+    "amount": 3109,
     "transactionDate": 1677223200000
   },
   {
@@ -59,7 +59,7 @@
     "senderId": 1,
     "receiverId": 4,
     "reference": "Bonus",
-    "amount": -2487,
+    "amount": 2487,
     "transactionDate": 1679181600000
   },
   {
@@ -77,7 +77,7 @@
     "senderId": 1,
     "receiverId": 4,
     "reference": "Refund",
-    "amount": -3240,
+    "amount": 3240,
     "transactionDate": 1679964000000
   },
   {
@@ -95,7 +95,7 @@
     "senderId": 4,
     "receiverId": 1,
     "reference": "Incentive",
-    "amount": -2127,
+    "amount": 2127,
     "transactionDate": 1678855200000
   },
   {
@@ -113,7 +113,7 @@
     "senderId": 4,
     "receiverId": 1,
     "reference": "Allowance",
-    "amount": -2356,
+    "amount": 2356,
     "transactionDate": 1674516000000
   },
   {
@@ -131,7 +131,7 @@
     "senderId": 4,
     "receiverId": 2,
     "reference": "Grant",
-    "amount": -3067,
+    "amount": 3067,
     "transactionDate": 1674069600000
   }
 ]

--- a/src/features/account/components/AccountTransactionForm.jsx
+++ b/src/features/account/components/AccountTransactionForm.jsx
@@ -69,9 +69,7 @@ export function AccountTransactionForm({
         paymentFormData.senderId,
         paymentFormData.receiverId,
         paymentFormData.reference,
-        authenticatedUserId === paymentFormData.receiverId
-          ? paymentFormData.amount
-          : -Math.abs(parseFloat(paymentFormData.amount))
+        parseFloat(paymentFormData.amount)
       )
     );
   }

--- a/src/features/transaction/components/TransactionListItem.jsx
+++ b/src/features/transaction/components/TransactionListItem.jsx
@@ -1,7 +1,8 @@
-import { useLocalStorage } from 'src/hooks';
+import { useAuthentication, useLocalStorage } from 'src/hooks';
 import { cn } from 'src/utils';
 
 export function TransactionListItem({ transaction }) {
+  const { authentication } = useAuthentication();
   const { userRepository, accountRepository } = useLocalStorage();
 
   const sender = userRepository.findById(
@@ -12,8 +13,8 @@ export function TransactionListItem({ transaction }) {
     accountRepository.findById(parseInt(transaction.receiverId)).userId
   );
 
-  const isTransactionOutgoing = (amount) => {
-    return amount < 0;
+  const isTransactionOutgoing = () => {
+    return authentication.getAuthenticatedUserId() !== receiver.id;
   };
 
   return (
@@ -21,16 +22,14 @@ export function TransactionListItem({ transaction }) {
       <td className="whitespace-nowrap p-4 text-sm font-normal text-gray-900 dark:text-white">
         {isTransactionOutgoing(transaction.amount) ? 'Payment to ' : 'Payment from '}
         <span className="font-semibold">
-          {isTransactionOutgoing(transaction.amount)
+          {isTransactionOutgoing()
             ? `${receiver.firstName} ${receiver.lastName}`
             : `${sender.firstName} ${sender.lastName}`}
         </span>
       </td>
       <td className={`whitespace-nowrap p-4 text-sm font-semibold text-gray-900 dark:text-white`}>
-        {isTransactionOutgoing(transaction.amount) ? (
-          <span className="text-red-800 dark:text-red-400">
-            -£{(transaction.amount * -1).toFixed(2)}
-          </span>
+        {isTransactionOutgoing() ? (
+          <span className="text-red-800 dark:text-red-400">-£{transaction.amount.toFixed(2)}</span>
         ) : (
           <span className="text-green-800 dark:border-green-500 dark:text-green-400">
             +£{transaction.amount.toFixed(2)}
@@ -52,12 +51,12 @@ export function TransactionListItem({ transaction }) {
             `mr-2 rounded-md border border-red-100 bg-red-100 px-2.5 py-0.5 text-xs font-medium`,
             {
               'border-red-100 bg-red-100 text-red-800 dark:border-red-500 dark:bg-gray-700 dark:text-red-400':
-                isTransactionOutgoing(transaction.amount),
+                isTransactionOutgoing(),
               'border-green-100 bg-green-100 text-green-800 dark:border-green-500 dark:bg-gray-700 dark:text-green-400':
-                !isTransactionOutgoing(transaction.amount)
+                !isTransactionOutgoing()
             }
           )}>
-          {isTransactionOutgoing(transaction.amount) ? 'Outgoing' : 'Incoming'}
+          {isTransactionOutgoing() ? 'Outgoing' : 'Incoming'}
         </span>
       </td>
     </tr>


### PR DESCRIPTION
This PR finally fixes the transaction type logic.

Ideally, transactions should be displayed by accounts as the transaction type is contextual.

When a transaction type is outgoing for one account, it is incoming for another.